### PR TITLE
ルーティングの整理とページネーションの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 
 gem 'rails', '~> 5.1.2'
 gem 'kaminari'
+gem 'kaminari-i18n'
 gem 'rails-i18n'
 gem 'missing_validators'
 gem 'puma', '~> 3.7'

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ end
 
 
 gem 'rails', '~> 5.1.2'
+gem 'will_paginate'
+gem 'will_paginate-bootstrap'
 gem 'rails-i18n'
 gem 'missing_validators'
 gem 'puma', '~> 3.7'

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,7 @@ end
 
 
 gem 'rails', '~> 5.1.2'
-gem 'will_paginate'
-gem 'will_paginate-bootstrap'
+gem 'kaminari'
 gem 'rails-i18n'
 gem 'missing_validators'
 gem 'puma', '~> 3.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,18 @@ GEM
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     i18n (0.8.6)
+    kaminari (1.0.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.0.1)
+      kaminari-activerecord (= 1.0.1)
+      kaminari-core (= 1.0.1)
+    kaminari-actionview (1.0.1)
+      actionview
+      kaminari-core (= 1.0.1)
+    kaminari-activerecord (1.0.1)
+      activerecord
+      kaminari-core (= 1.0.1)
+    kaminari-core (1.0.1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -247,9 +259,6 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    will_paginate (3.1.6)
-    will_paginate-bootstrap (1.0.1)
-      will_paginate (>= 3.0.3)
     xpath (2.1.0)
       nokogiri (~> 1.3)
     yard (0.9.9)
@@ -265,6 +274,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   factory_girl_rails
   faker
+  kaminari
   missing_validators
   pg
   pry-byebug
@@ -284,8 +294,6 @@ DEPENDENCIES
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
-  will_paginate
-  will_paginate-bootstrap
 
 BUNDLED WITH
    1.15.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,9 @@ GEM
       activerecord
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
+    kaminari-i18n (0.4.0)
+      kaminari
+      rails
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -275,6 +278,7 @@ DEPENDENCIES
   factory_girl_rails
   faker
   kaminari
+  kaminari-i18n
   missing_validators
   pg
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,9 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    will_paginate (3.1.6)
+    will_paginate-bootstrap (1.0.1)
+      will_paginate (>= 3.0.3)
     xpath (2.1.0)
       nokogiri (~> 1.3)
     yard (0.9.9)
@@ -281,6 +284,8 @@ DEPENDENCIES
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  will_paginate
+  will_paginate-bootstrap
 
 BUNDLED WITH
    1.15.1

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:session][:email])
     if user && user.authenticate(params[:session][:password])
       create_session(user)
-      redirect_to user
+      redirect_to root_path
     else
       flash.now[:danger] = t(:authentication_failed, scope: :flash)
       render "new"
@@ -17,7 +17,7 @@ class SessionsController < ApplicationController
 
   def destroy
     destroy_session
-    redirect_to root_path
+    redirect_to login_path
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
     if @user.save
       flash[:success] = t(:registration_success, scope: :flash)
       create_session(@user)
-      redirect_to @user
+      redirect_to user_path
     else
       render "new"
     end
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
   def update
     if current_user.update(user_params)
       flash[:success] = t(:update_success, scope: :flash)
-      redirect_to current_user
+      redirect_to user_path
     else
       render "edit"
     end

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -2,7 +2,7 @@ class WordsController < ApplicationController
   before_action :set_word, only: [:show, :edit, :update, :destroy]
 
   def index
-    @words = current_user.words.paginate(page: params[:page], per_page: 10)
+    @words = current_user.words.page(params[:page])
   end
 
   def new

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -2,7 +2,7 @@ class WordsController < ApplicationController
   before_action :set_word, only: [:show, :edit, :update, :destroy]
 
   def index
-    @words = current_user.words
+    @words = current_user.words.paginate(page: params[:page], per_page: 10)
   end
 
   def new

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='disabled'>
+  <%= content_tag :a, raw(t 'views.pagination.truncate') %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class='active'>
+    <%= content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
+  </li>
+<% else %>
+  <li>
+    <%= link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,13 @@
+<%= paginator.render do -%>
+  <ul class="pagination">
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <%= next_page_tag unless current_page.last? %>
+  </ul>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote %>
+</li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
         </div>
       <% if logged_in? %>
         <ul class="nav navbar-nav navbar-right">
-          <li><%= link_to t("title.profile"), current_user %></li>
+          <li><%= link_to t("title.profile"), user_path %></li>
           <li><%= link_to t("title.word_index"), words_path %></li>
           <li><%= link_to t("title.word_registration"), new_word_path %></li>
           <li><%= link_to t("link.logout"), logout_path, method: :delete %></li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
 <h1><%=t "title.profile" %></h1>
 <p><%= "#{User.human_attribute_name :name}：#{current_user.name}" %></p>
 <p><%= "#{User.human_attribute_name :email}：#{current_user.email}" %></p>
-<%= link_to t("link.edit"), edit_user_path(current_user) %>
+<%= link_to t("link.edit"), edit_user_path %>

--- a/app/views/words/index.html.erb
+++ b/app/views/words/index.html.erb
@@ -13,6 +13,5 @@
       </div>
     </li>
   <% end %>
-  <%= will_paginate @words, previous_label: "<<", next_label: ">>",
-      renderer: BootstrapPagination::Rails %>
+  <%= paginate @words %>
 </ul>

--- a/app/views/words/index.html.erb
+++ b/app/views/words/index.html.erb
@@ -13,4 +13,6 @@
       </div>
     </li>
   <% end %>
+  <%= will_paginate @words, previous_label: "<<", next_label: ">>",
+      renderer: BootstrapPagination::Rails %>
 </ul>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/config/locales/kaminari.ja.yml
+++ b/config/locales/kaminari.ja.yml
@@ -1,5 +1,0 @@
-ja:
-  views:
-    pagination:
-      previous: 前へ
-      next: 次へ

--- a/config/locales/kaminari.ja.yml
+++ b/config/locales/kaminari.ja.yml
@@ -1,0 +1,5 @@
+ja:
+  views:
+    pagination:
+      previous: 前へ
+      next: 次へ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   post "/login", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"
 
-  resource :user
+  resource :user, format: false, except: [:new, :create, :destroy]
   resources :words
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   post "/login", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"
 
-  resource :user, format: false, except: [:new, :create, :destroy]
+  resource :user, only: [:show, :edit, :update]
   resources :words
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
下記を実装しました。#17

- ルーティングの整理（未使用のURLの排除）
- ページネーションの追加（`will_paginate gem`にて実装）
　

**【悩んだポイント】**
> 6. URLの再設計
> たぶん、下記のようなことがやりたいんだと思うけど、現状そうなってないので直す。
> 知識が薄そうなので、ルーティングに関するRails Guideを読みながら対応する。

Userを単一のリソースに変更したので、`user/words`の様にあえてネストをする必要が無い（ユーザーは特定されているため）ように思い、スキップしたのですが問題ないでしょうか？
　

**【補足】**
> 5. ログにpassword_confirmationの値が表示されるかどうか目視で確認する。確認できたら、filter_parametersにpassword_confirmationを追加する。

下記の通り、`password_confirmation`が`[FILTERED]`だったので`filter_parameters`への追加はスキップしました。
![image](https://user-images.githubusercontent.com/29325694/29000199-723e2270-7a9f-11e7-8441-9b1b57e9c1da.png)