### PR TITLE
プロフィールページのブラッシュアップ

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,3 +1,36 @@
 // Place all the styles related to the Users controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+/*    Profile    */
+
+.profile {
+  img {
+    display: block;
+    border-radius: 100%;
+  }
+  .bio {
+    margin-top: 20px;
+    margin-bottom: 10px;
+    .item {
+      font-size: 20px;
+      margin-bottom: 5px;
+    }
+  }
+  h2 {
+    font-size: 30px;
+  }
+  h3 {
+    font-size: 16px;
+    font-weight: bold;
+  }
+  .knowledges_par_words {
+    font-size: 50px;
+    font-weight: bold;
+    margin-bottom: 50px;
+  }
+  .average_understanding {
+    font-weight: bold;
+    font-size: 50px;
+  }
+}

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,6 +1,6 @@
 module UsersHelper
   def get_gravatar_of(user, size: 80)
-    gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
+    gravatar_id = Digest::MD5.hexdigest(user.email.downcase)
     gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
     image_tag(gravatar_url, alt: user.name, class: "user_icon")
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -13,7 +13,7 @@ module UsersHelper
 
   def average_understanding
     knowledges = current_user.words.select("words.id, knowledges.understanding").joins(:knowledges).order("knowledges.understanding DESC").uniq
-    understandings = knowledges.map { |knowledge| knowledge.understanding }
+    understandings = knowledges.map(&:understanding)
     (understandings.sum.to_f / understandings.size).round(1)
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,5 +1,4 @@
 module UsersHelper
-
   def get_gravatar_of(user, size: 80)
     gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
     gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,20 @@
+module UsersHelper
+
+  def get_gravatar_of(user, size: 80)
+    gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
+    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
+    image_tag(gravatar_url, alt: user.name, class: "user_icon")
+  end
+
+  def knowledges_par_words
+    words = current_user.words.count
+    knowledges = current_user.words.with_knowledges.pluck(:id).count
+    "#{knowledges} / #{words}"
+  end
+
+  def average_understanding
+    knowledges = current_user.words.select("words.id, knowledges.understanding").joins(:knowledges).order("knowledges.understanding DESC").uniq
+    understandings = knowledges.map { |knowledge| knowledge.understanding }
+    (understandings.sum.to_f / understandings.size).round(1)
+  end
+end

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,4 +1,18 @@
-%h1= t("title.profile")
-%p= "#{User.human_attribute_name :name}：#{current_user.name}"
-%p= "#{User.human_attribute_name :email}：#{current_user.email}"
-= link_to t("link.edit"), edit_user_path
+.row
+  .col-sm-offset-2
+    %h1= t("title.profile")
+.row.profile
+  .col-sm-3.col-sm-offset-2
+    = get_gravatar_of(current_user, size: 200)
+    .bio
+      .item= current_user.name
+      .item= current_user.email
+    = link_to "編集", edit_user_path
+  .col-sm-3.col-sm-offset-1
+    %h2 学習進捗
+    %h3 知識 / 単語
+    .knowledges_par_words
+      = knowledges_par_words
+    %h3 平均の理解度
+    .average_understanding
+      = average_understanding

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -7,12 +7,15 @@
     .bio
       .item= current_user.name
       .item= current_user.email
-    = link_to "編集", edit_user_path
+    = link_to t("link.edit"), edit_user_path
   .col-sm-3.col-sm-offset-1
-    %h2 学習進捗
-    %h3 知識 / 単語
+    %h2= t("view.learning_progress")
+    %h3
+      = t("view.knowledge")
+      \/
+      = t("view.word")
     .knowledges_par_words
       = knowledges_par_words
-    %h3 平均の理解度
+    %h3= t("view.average_understanding")
     .average_understanding
       = average_understanding

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -30,3 +30,7 @@ ja:
     delete_confirmation: 本当に削除しますか？
     add_knowledge: 知識を登録
     star: " ★ "
+    learning_progress: 学習進捗
+    knowledge: 知識
+    word: 単語
+    average_understanding: 平均の理解度


### PR DESCRIPTION
下記を実装 #31 

- 登録メールアドレスを基にGravatarの画像を取得する機能の実装
- 単語、知識の数を表示する機能の実装
- 理解度の平均を表示する機能の実装（星での表示は未実装）